### PR TITLE
Explain better why -showBuildSettings command takes a lot of time.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1
-	github.com/bitrise-io/go-xcode v1.0.2
+	github.com/bitrise-io/go-xcode v1.0.5
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/hashicorp/go-version v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1 h1:4PBBhTUl6NthNJCTCexe/22e/crE6FTmYfcMAM/UirY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.2 h1:Uv/cBOJ/qZpitjOpyS8orafee3wk66OwvRTbqA2fr+4=
-github.com/bitrise-io/go-xcode v1.0.2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5 h1:T0I1ED5oDifbO57VSNxhLh+8T9vcdGt+5U/kOrzFKeQ=
+github.com/bitrise-io/go-xcode v1.0.5/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	logger.Println()
 	if xcodebuildVersion.MajorVersion >= 11 {
-		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
+		// Resolve Swift package dependencies, so running -showBuildSettings is faster
 		// Specifying a scheme is required for workspaces
 		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
 		if err := resolveDepsCmd.Run(); err != nil {

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/devportalservice"
+	"github.com/bitrise-io/go-xcode/utility"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/codesignasset"
@@ -20,6 +21,7 @@ import (
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/localcodesignasset"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager"
 	"github.com/bitrise-io/go-xcode/v2/codesign"
+	"github.com/bitrise-io/go-xcode/xcodebuild"
 )
 
 func failf(format string, args ...interface{}) {
@@ -41,6 +43,22 @@ func main() {
 	v1log.SetEnableDebugLog(cfg.VerboseLog) // for compatibility
 
 	cmdFactory := command.NewFactory(env.NewRepository())
+
+	xcodebuildVersion, err := utility.GetXcodeVersion()
+	if err != nil {
+		failf("Failed to determine Xcode version: %s", err)
+	}
+	logger.Printf("%s (%s)", xcodebuildVersion.Version, xcodebuildVersion.BuildVersion)
+
+	logger.Println()
+	if xcodebuildVersion.MajorVersion >= 11 {
+		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
+		// Specifying a scheme is required for workspaces
+		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(cfg.ProjectPath, cfg.Scheme, cfg.Configuration)
+		if err := resolveDepsCmd.Run(); err != nil {
+			logger.Warnf("%s", err)
+		}
+	}
 
 	// Analyze project
 	fmt.Println()

--- a/vendor/github.com/bitrise-io/go-xcode/LICENSE
+++ b/vendor/github.com/bitrise-io/go-xcode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Bitrise
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/bitrise-io/go-xcode/profileutil/util.go
+++ b/vendor/github.com/bitrise-io/go-xcode/profileutil/util.go
@@ -15,7 +15,7 @@ type ProfileType string
 const ProfileTypeIos ProfileType = "ios"
 
 // ProfileTypeMacOs ...
-const ProfileTypeMacOs ProfileType = "macos"
+const ProfileTypeMacOs ProfileType = "osx"
 
 // ProfileTypeTvOs ...
 const ProfileTypeTvOs ProfileType = "tvos"

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -1,0 +1,89 @@
+package xcodebuild
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
+)
+
+// ResolvePackagesCommandModel is a command builder
+// used to create `xcodebuild -resolvePackageDependencies` command
+type ResolvePackagesCommandModel struct {
+	projectPath   string
+	scheme        string
+	configuration string
+
+	customOptions []string
+}
+
+// NewResolvePackagesCommandModel returns a new ResolvePackagesCommandModel
+func NewResolvePackagesCommandModel(projectPath, scheme, configuration string) *ResolvePackagesCommandModel {
+	return &ResolvePackagesCommandModel{
+		projectPath:   projectPath,
+		scheme:        scheme,
+		configuration: configuration,
+	}
+}
+
+// SetCustomOptions sets custom options
+func (m *ResolvePackagesCommandModel) SetCustomOptions(customOptions []string) *ResolvePackagesCommandModel {
+	m.customOptions = customOptions
+	return m
+}
+
+func (m *ResolvePackagesCommandModel) cmdSlice() []string {
+	slice := []string{toolName}
+
+	if m.projectPath != "" {
+		if filepath.Ext(m.projectPath) == ".xcworkspace" {
+			slice = append(slice, "-workspace", m.projectPath)
+		} else {
+			slice = append(slice, "-project", m.projectPath)
+		}
+	}
+
+	if m.scheme != "" {
+		slice = append(slice, "-scheme", m.scheme)
+	}
+
+	if m.configuration != "" {
+		slice = append(slice, "-configuration", m.configuration)
+	}
+
+	slice = append(slice, "-resolvePackageDependencies")
+	slice = append(slice, m.customOptions...)
+
+	return slice
+}
+
+// Command returns the executable command
+func (m *ResolvePackagesCommandModel) command() command.Model {
+	cmdSlice := m.cmdSlice()
+	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
+}
+
+// Run runs the command and logs elapsed time
+func (m *ResolvePackagesCommandModel) Run() error {
+	var (
+		cmd   = m.command()
+		start = time.Now()
+	)
+
+	log.Printf("Resolving package dependencies...")
+
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
+	if err := cmd.Run(); err != nil {
+		if errorutil.IsExitStatusError(err) {
+			return fmt.Errorf("failed to resolve package dependencies")
+		}
+		return fmt.Errorf("failed to run command: %s", err)
+	}
+
+	log.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
+
+	return nil
+}

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -117,14 +119,23 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
-	cmd := c.Command()
+	var (
+		cmd   = c.Command()
+		start = time.Now()
+	)
+
+	log.Printf("Reading build settings...")
+
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
-			return nil, fmt.Errorf("%s command failed: output: %s", cmd.PrintableCommandArgs(), out)
+			return nil, fmt.Errorf("%s command failed, output: %s", cmd.PrintableCommandArgs(), out)
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
+
+	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
 
 	return parseBuildSettings(out)
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
@@ -17,6 +17,8 @@ const (
 	LegacyTargetType    TargetType = "PBXLegacyTarget"
 )
 
+const appClipProductType = "com.apple.product-type.application.on-demand-install-capable"
+
 // Target ...
 type Target struct {
 	Type                   TargetType
@@ -103,6 +105,22 @@ func (t Target) IsTestProduct() bool {
 // IsUITestProduct ...
 func (t Target) IsUITestProduct() bool {
 	return filepath.Ext(t.ProductType) == ".ui-testing"
+}
+
+func (t Target) isAppClipProduct() bool {
+	return t.ProductType == appClipProductType
+}
+
+// CanExportAppClip ...
+func (t Target) CanExportAppClip() bool {
+	deps := t.DependentTargets()
+	for _, target := range deps {
+		if target.isAppClipProduct() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func parseTarget(id string, objects serialized.Object) (Target, error) {

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
@@ -25,6 +25,10 @@ func (r BuildableReference) IsAppReference() bool {
 	return filepath.Ext(r.BuildableName) == ".app"
 }
 
+func (r BuildableReference) isTestProduct() bool {
+	return filepath.Ext(r.BuildableName) == ".xctest"
+}
+
 // ReferencedContainerAbsPath ...
 func (r BuildableReference) ReferencedContainerAbsPath(schemeContainerDir string) (string, error) {
 	s := strings.Split(r.ReferencedContainer, ":")
@@ -60,6 +64,10 @@ type BuildAction struct {
 type TestableReference struct {
 	Skipped            string `xml:"skipped,attr"`
 	BuildableReference BuildableReference
+}
+
+func (r TestableReference) isTestable() bool {
+	return r.Skipped == "NO" && r.BuildableReference.isTestProduct()
 }
 
 // MacroExpansion ...
@@ -229,4 +237,15 @@ func (s Scheme) AppBuildActionEntry() (BuildActionEntry, bool) {
 	}
 
 	return entry, (entry.BuildableReference.BlueprintIdentifier != "")
+}
+
+// IsTestable returns true if Test is a valid action
+func (s Scheme) IsTestable() bool {
+	for _, testEntry := range s.TestAction.Testables {
+		if testEntry.isTestable() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/bitrise-io/go-utils/ziputil
 github.com/bitrise-io/go-utils/v2/command
 github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/log
-# github.com/bitrise-io/go-xcode v1.0.2
+# github.com/bitrise-io/go-xcode v1.0.5
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

Improves the perceived slowness of the manage code signing phase; and adds log timestamps for debugging.

Resolves: https://bitrise.atlassian.net/browse/STEP-1834

### Changes

* Explicitely run -resolvePackageDependencies command to fetch Swift Packages.
* Adds timestamps and log -showBuildSettings commands.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
